### PR TITLE
makeClassWithInterface and useful init fn

### DIFF
--- a/lib/ClassUtils.lua
+++ b/lib/ClassUtils.lua
@@ -33,10 +33,7 @@ end
 
 function ClassUtils.makeClassWithInterface(name, interface)
 	local function getImplementsInterface(currentInterface)
-		assert(
-			tea.values(tea.callback)(currentInterface),
-			string.format("Class %s does not have a valid static interface", name)
-		)
+		assert(tea.values(tea.callback)(currentInterface), string.format("Class %s does not have a valid interface", name))
 		return tea.strictInterface(currentInterface)
 	end
 	local implementsInterface

--- a/lib/ClassUtils.lua
+++ b/lib/ClassUtils.lua
@@ -39,15 +39,12 @@ function ClassUtils.makeClassWithInterface(name, interface)
 		)
 		return tea.strictInterface(currentInterface)
 	end
-	local staticInterface = type(interface) ~= "function" and getImplementsInterface(interface)
-	local Class
-	Class =
+	local implementsInterface
+	local Class =
 		ClassUtils.makeClass(
 		name,
 		function(data)
 			data = data or {}
-			local dynamicInterface = type(interface) == "function" and getImplementsInterface(interface(Class))
-			local implementsInterface = dynamicInterface or staticInterface
 			assert(
 				implementsInterface(data),
 				string.format("Class %s cannot be instantiated as data does not match interface", name)
@@ -60,6 +57,8 @@ function ClassUtils.makeClassWithInterface(name, interface)
 			)
 		end
 	)
+	implementsInterface =
+		type(interface) == "function" and getImplementsInterface(interface(Class)) or getImplementsInterface(interface)
 	return Class
 end
 

--- a/lib/ClassUtils.lua
+++ b/lib/ClassUtils.lua
@@ -19,7 +19,8 @@ function ClassUtils.makeClass(name, constructor)
 		return instance
 	end
 	function Class.isInstance(value)
-		return ClassUtils.isA(value, Class)
+		local ok = ClassUtils.isA(value, Class)
+		return ok, ok and "" or string.format("Not a %s instance", name)
 	end
 	function Class:extend(name, subConstructor)
 		local SubClass = ClassUtils.makeClass(name, subConstructor or Class.new)
@@ -34,7 +35,9 @@ end
 
 function ClassUtils.makeClassWithInterface(name, interface)
 	local function getImplementsInterface(currentInterface)
-		assert(tea.values(tea.callback)(currentInterface), string.format("Class %s does not have a valid interface", name))
+		local ok, problem = tea.values(tea.callback)(currentInterface)
+		assert(ok, string.format([[Class %s does not have a valid interface
+%s]], name, problem or ""))
 		return tea.strictInterface(currentInterface)
 	end
 	local implementsInterface
@@ -43,10 +46,9 @@ function ClassUtils.makeClassWithInterface(name, interface)
 		name,
 		function(data)
 			data = data or {}
-			assert(
-				implementsInterface(data),
-				string.format("Class %s cannot be instantiated as data does not match interface", name)
-			)
+			local ok, problem = implementsInterface(data)
+			assert(ok, string.format([[Class %s cannot be instantiated
+%s]], name, problem or ""))
 			return TableUtils.mapKeys(
 				data,
 				function(_, key)

--- a/lib/ClassUtils.lua
+++ b/lib/ClassUtils.lua
@@ -14,8 +14,8 @@ function ClassUtils.makeClass(name, constructor)
 	function Class.new(...)
 		local instance = constructor(...)
 		setmetatable(instance, {__index = Class, __tostring = Class.toString})
-		if instance.init then
-			instance:init(...)
+		if instance._init then
+			instance:_init(...)
 		end
 		instance.Class = Class
 		return instance

--- a/lib/ClassUtils.lua
+++ b/lib/ClassUtils.lua
@@ -15,6 +15,7 @@ function ClassUtils.makeClass(name, constructor)
 		if instance.init then
 			instance:init(...)
 		end
+		instance.Class = Class
 		return instance
 	end
 	function Class.isInstance(value)

--- a/lib/ClassUtils.lua
+++ b/lib/ClassUtils.lua
@@ -3,6 +3,8 @@ local TableUtils = require(script.Parent.TableUtils)
 local ClassUtils = {}
 
 function ClassUtils.makeClass(name, constructor)
+	assert(tea.string(name), "Class name must be a string")
+	assert(tea.optional(tea.callback)(constructor), "Class constructor must be a function or nil")
 	constructor = constructor or function()
 			return {}
 		end
@@ -20,7 +22,7 @@ function ClassUtils.makeClass(name, constructor)
 	end
 	function Class.isInstance(value)
 		local ok = ClassUtils.isA(value, Class)
-		return ok, ok and "" or string.format("Not a %s instance", name)
+		return ok, not ok and string.format("Not a %s instance", name) or nil
 	end
 	function Class:extend(name, subConstructor)
 		local SubClass = ClassUtils.makeClass(name, subConstructor or Class.new)
@@ -37,7 +39,7 @@ function ClassUtils.makeClassWithInterface(name, interface)
 	local function getImplementsInterface(currentInterface)
 		local ok, problem = tea.values(tea.callback)(currentInterface)
 		assert(ok, string.format([[Class %s does not have a valid interface
-%s]], name, problem or ""))
+%s]], name, tostring(problem)))
 		return tea.strictInterface(currentInterface)
 	end
 	local implementsInterface
@@ -48,7 +50,7 @@ function ClassUtils.makeClassWithInterface(name, interface)
 			data = data or {}
 			local ok, problem = implementsInterface(data)
 			assert(ok, string.format([[Class %s cannot be instantiated
-%s]], name, problem or ""))
+%s]], name, tostring(problem)))
 			return TableUtils.mapKeys(
 				data,
 				function(_, key)

--- a/spec/ClassUtils_spec.lua
+++ b/spec/ClassUtils_spec.lua
@@ -269,7 +269,7 @@ describe(
 									}
 								)
 							end,
-							"Class Simple does not have a valid static interface"
+							"Class Simple does not have a valid interface"
 						)
 					end
 				)

--- a/spec/ClassUtils_spec.lua
+++ b/spec/ClassUtils_spec.lua
@@ -25,7 +25,7 @@ describe(
 						function MyClass:getFive()
 							return 5
 						end
-						function MyClass:init(amount)
+						function MyClass:_init(amount)
 							self.amount = amount + self:getFive()
 						end
 						local myInstance = MyClass.new(4)
@@ -341,7 +341,7 @@ bad value for key amount:
 							}
 						)
 
-						function MyClass:init()
+						function MyClass:_init()
 							self._nice = self:getDefaultAmount()
 						end
 						function MyClass:getDefaultAmount()
@@ -367,7 +367,7 @@ bad value for key amount:
 							}
 						)
 
-						function MyClass:init()
+						function MyClass:_init()
 							self._nice = self:getDefaultAmount()
 						end
 

--- a/spec/ClassUtils_spec.lua
+++ b/spec/ClassUtils_spec.lua
@@ -232,7 +232,9 @@ describe(
 							function()
 								MyClass.new({amount = 10})
 							end,
-							"Class Simple cannot be instantiated as data does not match interface"
+							[[Class Simple cannot be instantiated
+[interface] bad value for amount:
+	string expected, got number]]
 						)
 					end
 				)
@@ -253,7 +255,9 @@ describe(
 							function()
 								MyClass.new({amount = 10})
 							end,
-							"Class Simple cannot be instantiated as data does not match interface"
+							[[Class Simple cannot be instantiated
+[interface] bad value for amount:
+	string expected, got number]]
 						)
 					end
 				)
@@ -269,7 +273,9 @@ describe(
 									}
 								)
 							end,
-							"Class Simple does not have a valid interface"
+							[[Class Simple does not have a valid interface
+bad value for key amount:
+	function expected, got string]]
 						)
 					end
 				)
@@ -321,7 +327,9 @@ describe(
 							function()
 								MyClass.new({child = MyBadComposite.new()})
 							end,
-							"Class Simple cannot be instantiated as data does not match interface"
+							[[Class Simple cannot be instantiated
+[interface] bad value for child:
+	Not a Composite instance]]
 						)
 					end
 				)

--- a/spec/ClassUtils_spec.lua
+++ b/spec/ClassUtils_spec.lua
@@ -239,29 +239,6 @@ describe(
 					end
 				)
 				it(
-					"allows a class to be used",
-					function()
-						local MyClass =
-							ClassUtils.makeClassWithInterface(
-							"Simple",
-							{
-								amount = tea.string
-							}
-						)
-						function MyClass:getAmount()
-							return self._amount
-						end
-						assert.errors(
-							function()
-								MyClass.new({amount = 10})
-							end,
-							[[Class Simple cannot be instantiated
-[interface] bad value for amount:
-	string expected, got number]]
-						)
-					end
-				)
-				it(
 					"throws if the interface is malformed",
 					function()
 						assert.errors(


### PR DESCRIPTION
- replaced `makeConstructedClass` with `makeClassWithInterface(name, interface)`
    - interface is a table of tea types or a `function(Class)` which returns an interface that can be defined in terms of itself
    - prefer `FunctionUtils.is
- any class which implements an `init` function now has this called after the constructor once the metatable has been linked correctly
- any instances now has a Class field which points to whichever class it directly inherits from
- Class now has `Class.isInstance` which can be used in interfaces